### PR TITLE
Change a transformCallback function implementation in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,12 @@ class Item extends \yii\db\ActiveRecord
                 'fileExtensionAttribute' => 'fileExtension',
                 'fileVersionAttribute' => 'fileVersion',
                 'transformCallback' => function ($sourceFileName, $destinationFileName, $options) {
-                    Image::thumbnail($sourceFileName, $options['width'], $options['height'])->save($destinationFileName);
+                    try {
+                        Image::thumbnail($sourceFileName, $options['width'], $options['height'])->save($destinationFileName);
+                        return true;
+                    } catch (\Exception $e) {
+                        return false;
+                    }
                 },
                 'fileTransformations' => [
                     'origin', // no transformation


### PR DESCRIPTION
Hi Paul,

The code from readme example doesn't work because `transformFile` requires to return boolean status.
This status is used by `TransformFileBehavior::newFile`.
