### PR TITLE
`subDirTemplate` now accepts callable, new 'shorname' placeholder

### DIFF
--- a/tests/FileBehaviorTest.php
+++ b/tests/FileBehaviorTest.php
@@ -91,6 +91,15 @@ class FileBehaviorTest extends TestCase
         $actualSubDir = $model->getActualSubDir();
         $expectedActualSubDir = str_replace('{' . $testPropertyName . '}', $model->$testPropertyName, $testSubDirTemplate);
         $this->assertEquals($actualSubDir, $expectedActualSubDir, 'Actual sub dir can not parse property!');
+
+        $model->id = 54321;
+        $closure = function($model){
+            return 'test/' . md5($model->id) . '/subdir/template';
+        };
+        $model->subDirTemplate = $closure;
+        $actualSubDir = $model->getActualSubDir();
+        $expectedActualSubDir = $closure($model);
+        $this->assertEquals($actualSubDir, $expectedActualSubDir, 'Actual sub dir can not parse callable!');
     }
 
     /**


### PR DESCRIPTION
Paul, your '__model__' placeholder was described as 'base name' placeholder in time it does not parsed as base class name. I added a new one to avoid complications with existing software.

Also I added a functionality to parse subdir template as a callback to provide custom path parts like hashes or date/year/month so on. Very useful for someone like me, who loves to tune up all behaviours via 'bootstrap.php' file.